### PR TITLE
Update the arguments to trivy command

### DIFF
--- a/.github/workflows/ts-app-security.yml
+++ b/.github/workflows/ts-app-security.yml
@@ -25,8 +25,7 @@ jobs:
         uses: aquasecurity/trivy-action@b2933f565dbc598b29947660e66259e3c7bc8561
         with:
           image-ref: '${{ env.IMAGE_TAG }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to Github Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
Updates to the argument format in Trivy

```
WARN	Using `--template sarif.tpl` is deprecated. Please migrate to `--format sarif`. See https://github.com/aquasecurity/trivy/discussions/1571
```